### PR TITLE
🎨 Palette: Add sequential A-Z navigation to letter footer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2025-03-14 - Keyboard Accessibility & Tooltips for Icon-only Buttons
 **Learning:** Found that icon-only buttons lacked hover text (`title`) and `focus-visible` styles which are critical for screen reader users and keyboard navigation. Using Tailwind's `focus-visible:ring-2 focus-visible:outline-none` pattern prevents default outline rings and uses theme colors efficiently, ensuring it only triggers on keyboard focus.
 **Action:** Always verify keyboard navigation (Tab through the page) and add `focus-visible` to custom styled buttons and links, especially icon-only buttons.
+
+## 2025-03-28 - Added sequential A-Z pagination to letter footer
+**Learning:** Navigating a deeply nested directory (A-Z) without "Next/Previous" links causes high friction, forcing users to repeatedly hit "back" or return to the top navigation. Implementing robust sequential pagination (handling 'A' as first, 'Z' as last, and locking future weeks) significantly improves content discovery flows.
+**Action:** When working on paginated or sequential content (like a blog or directory list), always assess if bottom-of-page navigation exists to guide users naturally to the next piece of content. Add ARIA labels (e.g., `aria-label="Next Letter: B"`) to ensure screen reader context is maintained when navigating sequentially.

--- a/website/themes/cncf-theme/layouts/partials/letter-footer.html
+++ b/website/themes/cncf-theme/layouts/partials/letter-footer.html
@@ -1,10 +1,56 @@
+{{ $letter := .Params.letter | default "A" }}
+{{ $alphabet := split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
+{{ $currentIndex := 0 }}
+{{ range $i, $v := $alphabet }}
+    {{ if eq $v $letter }}
+        {{ $currentIndex = $i }}
+    {{ end }}
+{{ end }}
+
+{{ $currentWeekData := partial "get-current-week.html" . }}
+{{ $currentWeekIndex := 0 }}
+{{ if $currentWeekData }}
+    {{ $currentWeekIndex = $currentWeekData.index }}
+{{ end }}
+
 <div class="mt-16 flex items-center justify-between border-t border-slate-200 pt-8 mb-12">
-    <a href="/" class="flex items-center gap-2 px-4 py-2 text-slate-600 hover:text-blue-600 transition-colors font-semibold">
-        <i data-lucide="chevron-left" class="w-5 h-5"></i> Back to Overview
-    </a>
-    <div class="text-slate-400 text-sm font-medium">
-        Letter {{ .Params.letter | default "A" }}
+    <div class="flex-1">
+    {{ if gt $currentIndex 0 }}
+        {{ $prevIndex := sub $currentIndex 1 }}
+        {{ $prevLetter := index $alphabet $prevIndex }}
+        <a href="{{ "letters/" | relURL }}{{ $prevLetter | lower }}/" class="inline-flex items-center gap-2 px-4 py-2 text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded-lg transition-colors font-semibold" aria-label="Previous Letter: {{ $prevLetter }}">
+            <i data-lucide="chevron-left" class="w-5 h-5"></i> <span class="hidden sm:inline">Previous Letter</span>
+        </a>
+    {{ else }}
+        <button disabled aria-disabled="true" title="No previous letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
+            <i data-lucide="chevron-left" class="w-5 h-5"></i> <span class="hidden sm:inline">Previous Letter</span>
+        </button>
+    {{ end }}
     </div>
-    <!-- Placeholder for alignment -->
-    <div class="w-24"></div>
+
+    <div class="flex-1 flex justify-center">
+        <a href="/" class="flex items-center gap-2 px-4 py-2 text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded-lg transition-colors font-semibold" aria-label="Back to Overview">
+            <i data-lucide="layout-grid" class="w-5 h-5"></i> <span class="hidden sm:inline">Overview</span>
+        </a>
+    </div>
+
+    <div class="flex-1 flex justify-end">
+    {{ if lt $currentIndex 25 }}
+        {{ $nextIndex := add $currentIndex 1 }}
+        {{ $nextLetter := index $alphabet $nextIndex }}
+        {{ if le $nextIndex $currentWeekIndex }}
+            <a href="{{ "letters/" | relURL }}{{ $nextLetter | lower }}/" class="inline-flex items-center gap-2 px-4 py-2 text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded-lg transition-colors font-semibold" aria-label="Next Letter: {{ $nextLetter }}">
+                <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
+            </a>
+        {{ else }}
+            <button disabled aria-disabled="true" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed" title="The next letter is still locked! Check back in the coming weeks.">
+                <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
+            </button>
+        {{ end }}
+    {{ else }}
+        <button disabled aria-disabled="true" title="No next letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
+            <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
+        </button>
+    {{ end }}
+    </div>
 </div>

--- a/website/themes/cncf-theme/layouts/partials/letter-footer.html
+++ b/website/themes/cncf-theme/layouts/partials/letter-footer.html
@@ -1,11 +1,8 @@
-{{ $letter := .Params.letter | default "A" }}
+{{ $weekParam := .Params.week | default 0 }}
+{{ $currentIndex := int $weekParam }}
+{{ if lt $currentIndex 0 }}{{ $currentIndex = 0 }}{{ end }}
+{{ if gt $currentIndex 25 }}{{ $currentIndex = 25 }}{{ end }}
 {{ $alphabet := split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
-{{ $currentIndex := 0 }}
-{{ range $i, $v := $alphabet }}
-    {{ if eq $v $letter }}
-        {{ $currentIndex = $i }}
-    {{ end }}
-{{ end }}
 
 {{ $currentWeekData := partial "get-current-week.html" . }}
 {{ $currentWeekIndex := 0 }}
@@ -22,9 +19,9 @@
             <i data-lucide="chevron-left" class="w-5 h-5"></i> <span class="hidden sm:inline">Previous Letter</span>
         </a>
     {{ else }}
-        <button disabled aria-disabled="true" title="No previous letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
+        <span role="button" aria-disabled="true" aria-label="No previous letter" tabindex="0" title="No previous letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
             <i data-lucide="chevron-left" class="w-5 h-5"></i> <span class="hidden sm:inline">Previous Letter</span>
-        </button>
+        </span>
     {{ end }}
     </div>
 
@@ -43,14 +40,14 @@
                 <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
             </a>
         {{ else }}
-            <button disabled aria-disabled="true" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed" title="The next letter is still locked! Check back in the coming weeks.">
+            <span role="button" aria-disabled="true" aria-label="Next letter is still locked" tabindex="0" title="The next letter is still locked! Check back in the coming weeks." class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
                 <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
-            </button>
+            </span>
         {{ end }}
     {{ else }}
-        <button disabled aria-disabled="true" title="No next letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
+        <span role="button" aria-disabled="true" aria-label="No next letter" tabindex="0" title="No next letter" class="inline-flex items-center gap-2 px-4 py-2 text-slate-300 transition-colors font-semibold cursor-not-allowed">
             <span class="hidden sm:inline">Next Letter</span> <i data-lucide="chevron-right" class="w-5 h-5"></i>
-        </button>
+        </span>
     {{ end }}
     </div>
 </div>


### PR DESCRIPTION
💡 What: Added "Previous Letter" and "Next Letter" buttons to the bottom of the individual letter pages (`letter-footer.html`), mirroring the UX on the homepage but making it functional for sequential navigation.
🎯 Why: Users previously had to scroll to the top or return to the overview page to navigate to the next letter. This reduces friction and makes browsing the A-to-Z directory much more fluid and intuitive.
📸 Before/After: See Playwright video and screenshots for the new footer in action.
♿ Accessibility: Added `aria-label` describing the specific next/previous letter (e.g., "Next Letter: B"). Added `title` tooltips explaining why a button might be disabled (e.g., "The next letter is still locked!"). Ensured keyboard navigation is visible with `focus-visible` Tailwind classes.

---
*PR created automatically by Jules for task [6165109591854957150](https://jules.google.com/task/6165109591854957150) started by @xNok*