### PR TITLE
⚡ Optimize tracker loading in get_ready_tasks

### DIFF
--- a/benchmark_tracker.py
+++ b/benchmark_tracker.py
@@ -1,0 +1,28 @@
+
+import time
+import sys
+from pathlib import Path
+
+# Add src to sys.path
+sys.path.append(str(Path.cwd()))
+
+from src.tracker.yaml_backend import YAMLTrackerBackend
+
+def benchmark():
+    backend = YAMLTrackerBackend()
+
+    # Warm up
+    backend.get_ready_tasks()
+
+    start_time = time.perf_counter()
+    iterations = 10
+    for _ in range(iterations):
+        tasks = backend.get_ready_tasks()
+    end_time = time.perf_counter()
+
+    avg_time = (end_time - start_time) / iterations
+    print(f"Average time for get_ready_tasks: {avg_time:.4f} seconds")
+    print(f"Number of ready tasks found: {len(tasks)}")
+
+if __name__ == "__main__":
+    benchmark()

--- a/src/tracker/yaml_backend.py
+++ b/src/tracker/yaml_backend.py
@@ -176,12 +176,19 @@ class YAMLTrackerBackend:
         
         return pending_items
     
-    def can_start_task(self, week_letter: str, item: Optional[str], task_type: str) -> bool:
+    def can_start_task(
+        self,
+        week_letter: str,
+        item: Optional[str],
+        task_type: str,
+        tracker: Optional[WeekTracker] = None
+    ) -> bool:
         """Check if a task can be started (dependencies met)."""
         if not is_valid_task_type(task_type):
             return False
         
-        tracker = self.load_tracker(week_letter)
+        if tracker is None:
+            tracker = self.load_tracker(week_letter)
         
         return self._check_dependencies(tracker, item, task_type)
     
@@ -417,7 +424,7 @@ class YAMLTrackerBackend:
                 for task_type, task_record in item_tasks.tasks.items():
                     # Only include pending tasks where dependencies are met
                     if task_record.status == TaskStatus.PENDING:
-                        if self.can_start_task(letter, item_name, task_type):
+                        if self.can_start_task(letter, item_name, task_type, tracker=tracker):
                             config = get_task_config(task_type)
                             ready_tasks.append(ReadyTask(
                                 week_letter=letter,
@@ -429,7 +436,7 @@ class YAMLTrackerBackend:
             # Check week-level tasks
             for task_type, task_record in tracker.week_tasks.tasks.items():
                 if task_record.status == TaskStatus.PENDING:
-                    if self.can_start_task(letter, None, task_type):
+                    if self.can_start_task(letter, None, task_type, tracker=tracker):
                         config = get_task_config(task_type)
                         ready_tasks.append(ReadyTask(
                             week_letter=letter,


### PR DESCRIPTION
💡 **What:** Modified `can_start_task` to accept an optional pre-loaded `WeekTracker` object and updated `get_ready_tasks` to pass this object during its iterations.
🎯 **Why:** Previously, `get_ready_tasks` triggered a redundant file read (N+1 I/O) for every task check within a week, even though the tracker for that week was already loaded once at the beginning of the week loop.
📊 **Measured Improvement:** This change reduces file I/O from 1 + T reads to 1 read per week (where T is the number of pending tasks in that week). In a full run across 26 weeks, this significantly reduces disk overhead and YAML parsing. While direct benchmarking in the sandbox was limited by environment dependencies, the O(N*T) to O(N) reduction in file operations is a guaranteed architectural improvement.

---
*PR created automatically by Jules for task [12589370005176501896](https://jules.google.com/task/12589370005176501896) started by @xNok*