### PR TITLE
🎨 Palette: Add keyboard focus states to interactive elements

### DIFF
--- a/website/themes/cncf-theme/layouts/partials/hero.html
+++ b/website/themes/cncf-theme/layouts/partials/hero.html
@@ -11,11 +11,11 @@
                 This week we explore the backbone of modern infrastructure. From DNS to Runtimes, "{{ $current.letter }}" houses some of the most critical graduated projects in the ecosystem.
             </p>
             <div class="flex flex-wrap gap-4">
-                <a id="deep-dive-link" href="/letters/{{ lower $current.letter }}/" class="bg-white text-blue-900 px-6 py-3 rounded-xl font-bold hover:bg-blue-50 transition-colors flex items-center gap-2">
+                <a id="deep-dive-link" href="/letters/{{ lower $current.letter }}/" class="bg-white text-blue-900 px-6 py-3 rounded-xl font-bold hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-blue-900 focus-visible:outline-none transition-colors flex items-center gap-2">
                     <i data-lucide="book-open" class="w-4.5 h-4.5"></i> Deep Dive into <span id="current-letter-btn">{{ $current.letter }}</span>
                 </a>
-                <a href="https://landscape.cncf.io/" target="_blank" class="bg-blue-500/30 backdrop-blur-sm border border-white/20 px-6 py-3 rounded-xl font-bold hover:bg-blue-500/40 transition-colors">
-                    Full Landscape View
+                <a href="https://landscape.cncf.io/" target="_blank" rel="noopener noreferrer" aria-label="Full Landscape View (opens in a new tab)" class="bg-blue-500/30 backdrop-blur-sm border border-white/20 px-6 py-3 rounded-xl font-bold hover:bg-blue-500/40 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-blue-900 focus-visible:outline-none transition-colors flex items-center gap-2">
+                    Full Landscape View <i data-lucide="external-link" class="w-4 h-4"></i>
                 </a>
             </div>
         </div>

--- a/website/themes/cncf-theme/layouts/partials/recent-posts.html
+++ b/website/themes/cncf-theme/layouts/partials/recent-posts.html
@@ -4,7 +4,7 @@
             <h2 class="text-2xl font-bold text-slate-900">Latest Updates</h2>
             <p class="text-slate-500">Insights and news from our CNCF journey.</p>
         </div>
-        <a href="/posts/" class="text-sm font-semibold text-blue-600 hover:text-blue-700 flex items-center gap-1 group">
+        <a href="/posts/" class="text-sm font-semibold text-blue-600 hover:text-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded flex items-center gap-1 group">
             View all posts 
             <i data-lucide="arrow-right" class="w-4 h-4 group-hover:translate-x-1 transition-transform"></i>
         </a>
@@ -12,7 +12,7 @@
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         {{ range first 3 (where .Site.RegularPages "Type" "posts") }}
-        <a href="{{ .RelPermalink }}" class="group bg-white rounded-[2rem] border border-slate-200 overflow-hidden hover:border-blue-400 hover:shadow-2xl hover:shadow-blue-200/50 transition-all flex flex-col">
+        <a href="{{ .RelPermalink }}" class="group bg-white rounded-[2rem] border border-slate-200 overflow-hidden hover:border-blue-400 hover:shadow-2xl hover:shadow-blue-200/50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-all flex flex-col">
             <div class="aspect-video flex items-center justify-center relative overflow-hidden {{ if .Params.letter }}bg-slate-100 border-b border-slate-200{{ else }}bg-gradient-to-br from-orange-400 to-orange-600{{ end }}">
                 {{ if .Params.letter }}
                     <span class="text-7xl font-black text-slate-300 group-hover:text-blue-500/10 group-hover:scale-110 transition-all duration-700 uppercase">{{ .Params.letter }}</span>

--- a/website/themes/cncf-theme/static/css/style.css
+++ b/website/themes/cncf-theme/static/css/style.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.2.1 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -79,6 +79,7 @@
     --tracking-widest: 0.1em;
     --leading-tight: 1.25;
     --leading-relaxed: 1.625;
+    --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
     --radius-2xl: 1rem;
@@ -242,6 +243,20 @@
   }
 }
 @layer utilities {
+  .visible {
+    visibility: visible;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
+  }
   .absolute {
     position: absolute;
   }
@@ -259,6 +274,12 @@
   }
   .inset-0 {
     inset: calc(var(--spacing) * 0);
+  }
+  .start {
+    inset-inline-start: var(--spacing);
+  }
+  .end {
+    inset-inline-end: var(--spacing);
   }
   .top-0 {
     top: calc(var(--spacing) * 0);
@@ -1188,6 +1209,10 @@
       --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-slate-200) 60%, transparent) var(--tw-shadow-alpha), transparent);
     }
   }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
   .blur-3xl {
     --tw-blur: blur(var(--blur-3xl));
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -1525,9 +1550,128 @@
       }
     }
   }
-  .disabled\:opacity-30 {
-    &:disabled {
-      opacity: 30%;
+  .focus\:not-sr-only {
+    &:focus {
+      position: static;
+      width: auto;
+      height: auto;
+      padding: 0;
+      margin: 0;
+      overflow: visible;
+      clip-path: none;
+      white-space: normal;
+    }
+  }
+  .focus\:fixed {
+    &:focus {
+      position: fixed;
+    }
+  }
+  .focus\:top-4 {
+    &:focus {
+      top: calc(var(--spacing) * 4);
+    }
+  }
+  .focus\:left-4 {
+    &:focus {
+      left: calc(var(--spacing) * 4);
+    }
+  }
+  .focus\:z-\[100\] {
+    &:focus {
+      z-index: 100;
+    }
+  }
+  .focus\:rounded-md {
+    &:focus {
+      border-radius: var(--radius-md);
+    }
+  }
+  .focus\:bg-white {
+    &:focus {
+      background-color: var(--color-white);
+    }
+  }
+  .focus\:px-4 {
+    &:focus {
+      padding-inline: calc(var(--spacing) * 4);
+    }
+  }
+  .focus\:py-2 {
+    &:focus {
+      padding-block: calc(var(--spacing) * 2);
+    }
+  }
+  .focus\:font-bold {
+    &:focus {
+      --tw-font-weight: var(--font-weight-bold);
+      font-weight: var(--font-weight-bold);
+    }
+  }
+  .focus\:text-blue-600 {
+    &:focus {
+      color: var(--color-blue-600);
+    }
+  }
+  .focus\:shadow-lg {
+    &:focus {
+      --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-2 {
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-blue-600 {
+    &:focus {
+      --tw-ring-color: var(--color-blue-600);
+    }
+  }
+  .focus\:outline-none {
+    &:focus {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+  }
+  .focus-visible\:ring-2 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-amber-400 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-amber-400);
+    }
+  }
+  .focus-visible\:ring-blue-500 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-blue-500);
+    }
+  }
+  .focus-visible\:ring-white {
+    &:focus-visible {
+      --tw-ring-color: var(--color-white);
+    }
+  }
+  .focus-visible\:ring-offset-2 {
+    &:focus-visible {
+      --tw-ring-offset-width: 2px;
+      --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+    }
+  }
+  .focus-visible\:ring-offset-blue-900 {
+    &:focus-visible {
+      --tw-ring-offset-color: var(--color-blue-900);
+    }
+  }
+  .focus-visible\:outline-none {
+    &:focus-visible {
+      --tw-outline-style: none;
+      outline-style: none;
     }
   }
   .sm\:flex-row {
@@ -1808,6 +1952,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -1955,6 +2104,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;


### PR DESCRIPTION
💡 **What**: Added `focus-visible` styling to primary buttons in the hero section and recent posts, added an external link icon, and added missing `rel="noopener noreferrer"` and `aria-label` attributes.
🎯 **Why**: Previously, navigating the interface via keyboard lacked visible focus outlines, making it difficult for keyboard users. Opening external links did not visually indicate a new tab would open, and posed a minor security/performance risk without noopener.
📸 **Before/After**: See visual verification screenshots (focus outlines now highlight elements accurately).
♿ **Accessibility**: Enhanced keyboard navigation with high-contrast Tailwind focus rings. Improved screen reader context with `aria-label` and visual context for external links.

---
*PR created automatically by Jules for task [11537246073454622699](https://jules.google.com/task/11537246073454622699) started by @xNok*