### PR TITLE
🎨 Palette: Keyboard focus & External links accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-05-30 - Standardized Empty States
 **Learning:** Generic unstyled text like "No data available" provides poor UX and lacks visual hierarchy. Creating a consistent, styled empty state pattern using `bg-slate-50`, dashed borders, and a Lucide icon (like `inbox`) significantly improves the visual appeal and provides helpful context when data is missing.
 **Action:** Use this standard Tailwind empty state design pattern (`bg-slate-50 border-2 border-dashed border-slate-200 rounded-2xl p-12 text-center flex flex-col items-center justify-center`) across all pages when handling missing or empty data.
+
+## 2025-05-31 - Keyboard Accessibility & External Links context
+**Learning:** We need to ensure that all navigation links, especially breadcrumbs and sidebar links, have `focus-visible` styles so that keyboard users can easily tell where they are when navigating through the site. For external links opening in a new tab (`target="_blank"`), we should also add `rel="noopener noreferrer"` and an `aria-label` like "Opens in a new tab" to provide screen reader users with necessary context.
+**Action:** Consistently apply `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded` across links, and verify the correct attributes on `target="_blank"` elements across all layouts.

--- a/website/themes/cncf-theme/layouts/letters/list.html
+++ b/website/themes/cncf-theme/layouts/letters/list.html
@@ -5,7 +5,7 @@
     <main id="main-content" tabindex="-1" class="max-w-7xl mx-auto px-6 py-12">
         <div class="mb-10 pt-4">
             <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 mb-8">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
+                <a href="/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Home</a>
                 <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
                 <span class="text-slate-900">Letter {{ .Params.letter }}</span>
             </div>
@@ -53,7 +53,7 @@
                                             <!-- Assuming logos might be available, but avoiding broken images for now -->
                                             <!-- <img src="https://landscape.cncf.io/logos/{{ .logo }}" class="w-8 h-8 object-contain" alt="{{ .name }} logo"> -->
                                             {{ end }}
-                                            <a href="/tools/{{ $sanitizedName }}/" class="text-xl font-bold group-hover:text-blue-600 transition-colors">{{ .name }}</a>
+                                            <a href="/tools/{{ $sanitizedName }}/" class="text-xl font-bold group-hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">{{ .name }}</a>
                                         </div>
                                         
                                         {{ if .description }}
@@ -76,12 +76,12 @@
                                         <div class="flex items-center justify-between pt-4 border-t border-slate-100 text-xs font-medium text-slate-400">
                                             <div class="flex gap-3">
                                                 {{ if .repo_url }}
-                                                <a href="{{ .repo_url }}" target="_blank" class="flex items-center gap-1 hover:text-blue-600"><i data-lucide="github" class="w-3 h-3"></i> Repo</a>
+                                                <a href="{{ .repo_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .name }} GitHub Repository (opens in a new tab)" class="flex items-center gap-1 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded"><i data-lucide="github" class="w-3 h-3"></i> Repo</a>
                                                 {{ end }}
                                                 {{ if .homepage_url }}
-                                                <a href="{{ .homepage_url }}" target="_blank" class="flex items-center gap-1 hover:text-blue-600"><i data-lucide="external-link" class="w-3 h-3"></i> Web</a>
+                                                <a href="{{ .homepage_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ .name }} Official Website (opens in a new tab)" class="flex items-center gap-1 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded"><i data-lucide="external-link" class="w-3 h-3"></i> Web</a>
                                                 {{ end }}
-                                                <a href="/tools/{{ $sanitizedName }}/" class="flex items-center gap-1 hover:text-blue-600 ml-auto"><i data-lucide="arrow-right" class="w-3 h-3"></i> Details</a>
+                                                <a href="/tools/{{ $sanitizedName }}/" class="flex items-center gap-1 hover:text-blue-600 ml-auto focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded"><i data-lucide="arrow-right" class="w-3 h-3"></i> Details</a>
                                             </div>
                                         </div>
                                     </div>
@@ -102,7 +102,7 @@
             <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 {{ range (seq 0 25) }}
                     {{ $char := printf "%c" (add . 65) }}
-                    <a href="/letters/{{ $char }}/" class="block p-4 bg-white rounded-lg border border-slate-200 hover:border-blue-500 hover:shadow-md text-center font-bold text-xl text-slate-700 hover:text-blue-600 transition-all">
+                    <a href="/letters/{{ $char }}/" class="block p-4 bg-white rounded-lg border border-slate-200 hover:border-blue-500 hover:shadow-md text-center font-bold text-xl text-slate-700 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-all">
                         {{ $char }}
                     </a>
                 {{ end }}

--- a/website/themes/cncf-theme/layouts/tools/single.html
+++ b/website/themes/cncf-theme/layouts/tools/single.html
@@ -6,10 +6,10 @@
         <!-- Breadcrumb Navigation -->
         <div class="mb-8 lg:max-w-4xl lg:mx-auto pt-4">
             <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
+                <a href="/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Home</a>
                 <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
                 {{ $letter := .Params.letter }}
-                <a href="/letters/{{ $letter }}/" class="hover:text-blue-600 transition-colors">Letter {{ $letter }}</a>
+                <a href="/letters/{{ $letter }}/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Letter {{ $letter }}</a>
                 <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
                 <span class="text-slate-900">{{ .Params.project_name }}</span>
             </div>
@@ -36,12 +36,12 @@
 
             <div class="flex gap-4 text-sm">
                 {{ if .Params.repo_url }}
-                <a href="{{ .Params.repo_url }}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 transition-colors">
+                <a href="{{ .Params.repo_url }}" target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository (opens in a new tab)" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-colors">
                     <i data-lucide="github" class="w-4 h-4"></i> GitHub Repository
                 </a>
                 {{ end }}
                 {{ if .Params.homepage_url }}
-                <a href="{{ .Params.homepage_url }}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 transition-colors">
+                <a href="{{ .Params.homepage_url }}" target="_blank" rel="noopener noreferrer" aria-label="Official Website (opens in a new tab)" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-colors">
                     <i data-lucide="external-link" class="w-4 h-4"></i> Official Website
                 </a>
                 {{ end }}
@@ -119,7 +119,7 @@
                     <ul class="space-y-2">
                         {{ range .Params.related_tools }}
                         <li>
-                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline">
+                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">
                                 {{ . }}
                             </a>
                         </li>
@@ -133,7 +133,7 @@
         <!-- Navigation Footer -->
         <div class="mt-12 flex gap-4 justify-between">
             {{ $letter := .Params.letter }}
-            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 transition-colors">
+            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-colors">
                 <i data-lucide="arrow-left" class="w-4 h-4"></i> Back to Letter {{ $letter }}
             </a>
         </div>


### PR DESCRIPTION
This PR improves accessibility by ensuring all navigation links (breadcrumbs, related tools) have visible focus states for keyboard users (`focus-visible:ring-2`). It also improves screen reader context and security for external links (GitHub repos, websites) by adding `aria-label="..."` and `rel="noopener noreferrer"`. Also logged this standard pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [10381002798142763342](https://jules.google.com/task/10381002798142763342) started by @xNok*