### PR TITLE
🎨 Palette: Implement semantic breadcrumbs and focus states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-05-30 - Standardized Empty States
 **Learning:** Generic unstyled text like "No data available" provides poor UX and lacks visual hierarchy. Creating a consistent, styled empty state pattern using `bg-slate-50`, dashed borders, and a Lucide icon (like `inbox`) significantly improves the visual appeal and provides helpful context when data is missing.
 **Action:** Use this standard Tailwind empty state design pattern (`bg-slate-50 border-2 border-dashed border-slate-200 rounded-2xl p-12 text-center flex flex-col items-center justify-center`) across all pages when handling missing or empty data.
+
+## 2026-06-27 - Semantic Breadcrumbs
+**Learning:** Generic `div`-based breadcrumbs lack structure for screen readers. A true breadcrumb trail needs a `<nav aria-label="Breadcrumb">` wrapping an `<ol>` list. It's also crucial to mark the active, current page with `aria-current="page"` and to hide decorative separators from screen readers using `aria-hidden="true"`. Finally, individual breadcrumb links should have `focus-visible` styles for keyboard users.
+**Action:** Always implement breadcrumbs using the `<nav aria-label="Breadcrumb"><ol><li>...</li></ol></nav>` pattern. Ensure the active item has `aria-current="page"` and decorative items are hidden with `aria-hidden="true"`.

--- a/website/themes/cncf-theme/layouts/letters/list.html
+++ b/website/themes/cncf-theme/layouts/letters/list.html
@@ -4,11 +4,19 @@
 
     <main id="main-content" tabindex="-1" class="max-w-7xl mx-auto px-6 py-12">
         <div class="mb-10 pt-4">
-            <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 mb-8">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
-                <span class="text-slate-900">Letter {{ .Params.letter }}</span>
-            </div>
+            <nav aria-label="Breadcrumb" class="mb-8">
+                <ol class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 m-0 p-0 list-none">
+                    <li>
+                        <a href="/" class="hover:text-blue-600 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">Home</a>
+                    </li>
+                    <li aria-hidden="true" class="flex items-center">
+                        <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                    </li>
+                    <li>
+                        <span class="text-slate-900" aria-current="page">Letter {{ .Params.letter }}</span>
+                    </li>
+                </ol>
+            </nav>
             
             <h1 class="text-4xl md:text-5xl font-black text-slate-900 mb-4 tracking-tight">
                 Letter {{ .Params.letter }} Journey
@@ -102,7 +110,7 @@
             <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 {{ range (seq 0 25) }}
                     {{ $char := printf "%c" (add . 65) }}
-                    <a href="/letters/{{ $char }}/" class="block p-4 bg-white rounded-lg border border-slate-200 hover:border-blue-500 hover:shadow-md text-center font-bold text-xl text-slate-700 hover:text-blue-600 transition-all">
+                    <a href="/letters/{{ $char }}/" class="block p-4 bg-white rounded-lg border border-slate-200 hover:border-blue-500 hover:shadow-md text-center font-bold text-xl text-slate-700 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-all">
                         {{ $char }}
                     </a>
                 {{ end }}

--- a/website/themes/cncf-theme/layouts/tools/single.html
+++ b/website/themes/cncf-theme/layouts/tools/single.html
@@ -4,16 +4,26 @@
 
     <main id="main-content" tabindex="-1" class="max-w-7xl mx-auto px-6 py-12">
         <!-- Breadcrumb Navigation -->
-        <div class="mb-8 lg:max-w-4xl lg:mx-auto pt-4">
-            <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+        <nav aria-label="Breadcrumb" class="mb-8 lg:max-w-4xl lg:mx-auto pt-4">
+            <ol class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 m-0 p-0 list-none">
+                <li>
+                    <a href="/" class="hover:text-blue-600 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">Home</a>
+                </li>
+                <li aria-hidden="true" class="flex items-center">
+                    <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                </li>
                 {{ $letter := .Params.letter }}
-                <a href="/letters/{{ $letter }}/" class="hover:text-blue-600 transition-colors">Letter {{ $letter }}</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
-                <span class="text-slate-900">{{ .Params.project_name }}</span>
-            </div>
-        </div>
+                <li>
+                    <a href="/letters/{{ $letter | lower }}/" class="hover:text-blue-600 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">Letter {{ $letter }}</a>
+                </li>
+                <li aria-hidden="true" class="flex items-center">
+                    <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                </li>
+                <li>
+                    <span class="text-slate-900" aria-current="page">{{ .Params.project_name }}</span>
+                </li>
+            </ol>
+        </nav>
 
         <!-- Project Header -->
         <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-8 lg:max-w-4xl lg:mx-auto">
@@ -119,7 +129,7 @@
                     <ul class="space-y-2">
                         {{ range .Params.related_tools }}
                         <li>
-                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline">
+                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded inline-block">
                                 {{ . }}
                             </a>
                         </li>
@@ -133,7 +143,7 @@
         <!-- Navigation Footer -->
         <div class="mt-12 flex gap-4 justify-between">
             {{ $letter := .Params.letter }}
-            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 transition-colors">
+            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-colors">
                 <i data-lucide="arrow-left" class="w-4 h-4"></i> Back to Letter {{ $letter }}
             </a>
         </div>

--- a/website/themes/cncf-theme/static/css/style.css
+++ b/website/themes/cncf-theme/static/css/style.css
@@ -43,6 +43,7 @@
     --color-white: #fff;
     --spacing: 0.25rem;
     --container-xs: 20rem;
+    --container-md: 28rem;
     --container-lg: 32rem;
     --container-xl: 36rem;
     --container-2xl: 42rem;
@@ -296,9 +297,6 @@
   .right-\[-5\%\] {
     right: -5%;
   }
-  .isolate {
-    isolation: isolate;
-  }
   .-z-10 {
     z-index: calc(10 * -1);
   }
@@ -308,8 +306,8 @@
   .z-50 {
     z-index: 50;
   }
-  .col-span-3 {
-    grid-column: span 3 / span 3;
+  .col-span-1 {
+    grid-column: span 1 / span 1;
   }
   .container {
     width: 100%;
@@ -328,6 +326,9 @@
     @media (width >= 96rem) {
       max-width: 96rem;
     }
+  }
+  .m-0 {
+    margin: calc(var(--spacing) * 0);
   }
   .mx-auto {
     margin-inline: auto;
@@ -524,6 +525,9 @@
   .max-w-lg {
     max-width: var(--container-lg);
   }
+  .max-w-md {
+    max-width: var(--container-md);
+  }
   .max-w-none {
     max-width: none;
   }
@@ -556,6 +560,9 @@
   }
   .cursor-not-allowed {
     cursor: not-allowed;
+  }
+  .list-none {
+    list-style-type: none;
   }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
@@ -671,6 +678,10 @@
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -853,6 +864,9 @@
   .object-contain {
     object-fit: contain;
   }
+  .p-0 {
+    padding: calc(var(--spacing) * 0);
+  }
   .p-2 {
     padding: calc(var(--spacing) * 2);
   }
@@ -864,6 +878,9 @@
   }
   .p-8 {
     padding: calc(var(--spacing) * 8);
+  }
+  .p-12 {
+    padding: calc(var(--spacing) * 12);
   }
   .px-2 {
     padding-inline: calc(var(--spacing) * 2);
@@ -1684,6 +1701,11 @@
       padding-inline: calc(var(--spacing) * 6);
     }
   }
+  .md\:col-span-2 {
+    @media (width >= 48rem) {
+      grid-column: span 2 / span 2;
+    }
+  }
   .md\:flex {
     @media (width >= 48rem) {
       display: flex;
@@ -1760,6 +1782,11 @@
   .lg\:col-span-2 {
     @media (width >= 64rem) {
       grid-column: span 2 / span 2;
+    }
+  }
+  .lg\:col-span-3 {
+    @media (width >= 64rem) {
+      grid-column: span 3 / span 3;
     }
   }
   .lg\:mx-auto {


### PR DESCRIPTION
🎨 Palette: Implement semantic breadcrumbs and focus states

💡 What: Replaced generic `div`-based breadcrumbs with semantic `<nav aria-label="Breadcrumb">` and `<ol>` lists in `tools/single.html` and `letters/list.html`. Added missing `focus-visible` classes to breadcrumbs, footer links, and sidebar links. Logged learnings in `.Jules/palette.md`.
🎯 Why: Generic `div` breadcrumbs provide no structure for screen readers. Using proper HTML5 `<nav>` elements, `aria-current="page"`, and hiding chevrons with `aria-hidden="true"` vastly improves accessibility. The added `focus-visible` states ensure keyboard navigation works seamlessly across these layout elements.
♿ Accessibility: Improved screen reader navigation for breadcrumbs and added visible focus rings for keyboard users.

---
*PR created automatically by Jules for task [142074627242787442](https://jules.google.com/task/142074627242787442) started by @xNok*