### PR TITLE
🎨 Palette: Implement semantic and accessible breadcrumbs

### DIFF
--- a/website/themes/cncf-theme/layouts/letters/list.html
+++ b/website/themes/cncf-theme/layouts/letters/list.html
@@ -4,11 +4,19 @@
 
     <main id="main-content" tabindex="-1" class="max-w-7xl mx-auto px-6 py-12">
         <div class="mb-10 pt-4">
-            <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 mb-8">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
-                <span class="text-slate-900">Letter {{ .Params.letter }}</span>
-            </div>
+            <nav aria-label="Breadcrumb" class="mb-8">
+                <ol class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 m-0 p-0 list-none">
+                    <li>
+                        <a href="/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Home</a>
+                    </li>
+                    <li aria-hidden="true" class="flex items-center">
+                        <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                    </li>
+                    <li>
+                        <span class="text-slate-900" aria-current="page">Letter {{ .Params.letter }}</span>
+                    </li>
+                </ol>
+            </nav>
             
             <h1 class="text-4xl md:text-5xl font-black text-slate-900 mb-4 tracking-tight">
                 Letter {{ .Params.letter }} Journey

--- a/website/themes/cncf-theme/layouts/tools/single.html
+++ b/website/themes/cncf-theme/layouts/tools/single.html
@@ -4,16 +4,26 @@
 
     <main id="main-content" tabindex="-1" class="max-w-7xl mx-auto px-6 py-12">
         <!-- Breadcrumb Navigation -->
-        <div class="mb-8 lg:max-w-4xl lg:mx-auto pt-4">
-            <div class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400">
-                <a href="/" class="hover:text-blue-600 transition-colors">Home</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
-                {{ $letter := .Params.letter }}
-                <a href="/letters/{{ $letter }}/" class="hover:text-blue-600 transition-colors">Letter {{ $letter }}</a>
-                <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
-                <span class="text-slate-900">{{ .Params.project_name }}</span>
-            </div>
-        </div>
+        <nav aria-label="Breadcrumb" class="mb-8 lg:max-w-4xl lg:mx-auto pt-4">
+            <ol class="flex items-center gap-3 text-xs font-bold uppercase tracking-widest text-slate-400 m-0 p-0 list-none">
+                <li>
+                    <a href="/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Home</a>
+                </li>
+                <li aria-hidden="true" class="flex items-center">
+                    <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                </li>
+                <li>
+                    {{ $letter := .Params.letter }}
+                    <a href="/letters/{{ $letter }}/" class="hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Letter {{ $letter }}</a>
+                </li>
+                <li aria-hidden="true" class="flex items-center">
+                    <i data-lucide="chevron-right" class="w-3 h-3 text-slate-300"></i>
+                </li>
+                <li>
+                    <span class="text-slate-900" aria-current="page">{{ .Params.project_name }}</span>
+                </li>
+            </ol>
+        </nav>
 
         <!-- Project Header -->
         <div class="bg-white rounded-2xl border border-slate-200 p-8 mb-8 lg:max-w-4xl lg:mx-auto">


### PR DESCRIPTION
This PR updates the breadcrumb navigation in the application (`website/themes/cncf-theme/layouts/letters/list.html` and `website/themes/cncf-theme/layouts/tools/single.html`) to use semantic markup for better screen reader and keyboard accessibility, while keeping the exact visual layout and styling.

🎯 Why:
Non-semantic `div` elements with text-based separators are not announced correctly by screen readers. A `nav` region labeled "Breadcrumb" holding an ordered list communicates the hierarchy properly. We also hide visual decorators with `aria-hidden` and added missing focus indicators.

---
*PR created automatically by Jules for task [4048784786701876057](https://jules.google.com/task/4048784786701876057) started by @xNok*