### PR TITLE
🎨 Palette: Improve keyboard accessibility with focus-visible on links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,8 @@
 ## 2025-05-30 - Standardized Empty States
 **Learning:** Generic unstyled text like "No data available" provides poor UX and lacks visual hierarchy. Creating a consistent, styled empty state pattern using `bg-slate-50`, dashed borders, and a Lucide icon (like `inbox`) significantly improves the visual appeal and provides helpful context when data is missing.
 **Action:** Use this standard Tailwind empty state design pattern (`bg-slate-50 border-2 border-dashed border-slate-200 rounded-2xl p-12 text-center flex flex-col items-center justify-center`) across all pages when handling missing or empty data.
+
+
+## 2025-10-26 - Missing focus-visible on links
+**Learning:** Some anchor (`<a>`) links, specifically those used for generic text links or post titles, were missing `focus-visible` styles. While standard buttons and major navigation elements had them, inline or list-based links without default underlines can be difficult to track with keyboard navigation if they lack a clear focus state.
+**Action:** Always ensure that all interactive elements, including inline links and list items acting as links, have explicit `focus-visible` styles (e.g., `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded`) to ensure they are accessible via keyboard navigation.

--- a/website/themes/cncf-theme/layouts/posts/list.html
+++ b/website/themes/cncf-theme/layouts/posts/list.html
@@ -45,14 +45,14 @@
                     </div>
                     
                     <h2 class="text-3xl font-black mb-4 tracking-tight text-slate-900 group-hover:text-blue-600 transition-colors leading-tight">
-                        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                        <a href="{{ .RelPermalink }}" class="focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">{{ .Title }}</a>
                     </h2>
                     
                     <div class="text-slate-500 mb-6 line-clamp-2 leading-relaxed text-sm">
                         {{ .Summary | default "Join us as we explore the projects and tools in the current phase of the CNCF landscape." }}
                     </div>
 
-                    <a href="{{ .RelPermalink }}" class="inline-flex items-center gap-2 font-bold text-slate-900 group-hover:text-blue-600 transition-colors">
+                    <a href="{{ .RelPermalink }}" class="inline-flex items-center gap-2 font-bold text-slate-900 group-hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">
                         Read full story
                         <i data-lucide="arrow-right" class="w-4 h-4 group-hover:translate-x-1 transition-transform"></i>
                     </a>

--- a/website/themes/cncf-theme/layouts/tools/single.html
+++ b/website/themes/cncf-theme/layouts/tools/single.html
@@ -129,7 +129,7 @@
                     <ul class="space-y-2">
                         {{ range .Params.related_tools }}
                         <li>
-                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline">
+                            <a href="/tools/{{ . | lower | replaceRE " " "_" | replaceRE "&" "and" | replaceRE "/" "_" | replaceRE "\\." "_" | replaceRE "," "" }}/" class="text-blue-600 hover:text-blue-800 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded">
                                 {{ . }}
                             </a>
                         </li>
@@ -143,7 +143,7 @@
         <!-- Navigation Footer -->
         <div class="mt-12 flex gap-4 justify-between">
             {{ $letter := .Params.letter }}
-            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 transition-colors">
+            <a href="/letters/{{ $letter }}/" class="inline-flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg hover:bg-blue-100 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition-colors">
                 <i data-lucide="arrow-left" class="w-4 h-4"></i> Back to Letter {{ $letter }}
             </a>
         </div>


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind classes to missing anchor tags in `tools/single.html` and `posts/list.html`.
🎯 Why: To ensure that all interactive elements have a clear visual indicator when navigated via keyboard.
📸 Before/After: Links that previously had no outline when tabbed to now have a clear blue ring.
♿ Accessibility: Improves keyboard navigation support across the site.

---
*PR created automatically by Jules for task [11596174421724281268](https://jules.google.com/task/11596174421724281268) started by @xNok*