### PR TITLE
feat: Add overlay mechanism to patch missing fields in ETL

### DIFF
--- a/data/extras/excluded_items.yaml
+++ b/data/extras/excluded_items.yaml
@@ -800,6 +800,7 @@
 - NTT DATA (KCSP)
 - NTT DATA (member)
 - NVIDIA (member)
+- NVIDIA NIM on EKS
 - Nasdaq (supporter)
 - National Information Society Agency (member)
 - Natwest (member)

--- a/data/index/categories.yaml
+++ b/data/index/categories.yaml
@@ -648,6 +648,7 @@
     - Amazon Elastic Kubernetes Service Anywhere (Amazon EKS Anywhere)
     - Cybozu Kubernetes Engine
     - Gardener
+    - kiac
     - kind
     - kOps
     - Kubeasz

--- a/data/index/category_item_index.yaml
+++ b/data/index/category_item_index.yaml
@@ -628,6 +628,7 @@ Platform:
   - Amazon Elastic Kubernetes Service Anywhere (Amazon EKS Anywhere)
   - Cybozu Kubernetes Engine
   - Gardener
+  - kiac
   - kind
   - kOps
   - Kubeasz

--- a/data/overlay/overlay.yaml
+++ b/data/overlay/overlay.yaml
@@ -1,2 +1,6 @@
 Packer:
   description: "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration."
+Score:
+  twitter: "https://twitter.com/score_dev"
+Tinkerbell:
+  description: "Bare metal provisioning engine, supporting network and ISO booting, BMC interactions, metadata service, and workflow engine."

--- a/data/overlay/overlay.yaml
+++ b/data/overlay/overlay.yaml
@@ -1,6 +1,8 @@
 Packer:
-  description: "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration."
+  description: Packer is a tool for creating identical machine images for multiple
+    platforms from a single source configuration.
 Score:
-  twitter: "https://twitter.com/score_dev"
-Tinkerbell:
-  description: "Bare metal provisioning engine, supporting network and ISO booting, BMC interactions, metadata service, and workflow engine."
+  twitter: https://twitter.com/score_dev
+Terranetes Controller:
+  description: Bare metal provisioning engine, supporting network and ISO booting,
+    BMC interactions, metadata service, and workflow engine.

--- a/data/overlay/overlay.yaml
+++ b/data/overlay/overlay.yaml
@@ -1,0 +1,2 @@
+Packer:
+  description: "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration."

--- a/data/weeks/15-P/categories/app_definition_and_development_application_definition_image_build.yaml
+++ b/data/weeks/15-P/categories/app_definition_and_development_application_definition_image_build.yaml
@@ -1,6 +1,4 @@
 - crunchbase: https://www.crunchbase.com/organization/hashicorp
-  description: Packer is a tool for creating identical machine images for multiple
-    platforms from a single source configuration.
   featured: true
   homepage_url: https://www.packer.io/
   logo: packer.svg

--- a/data/weeks/15-P/categories/app_definition_and_development_application_definition_image_build.yaml
+++ b/data/weeks/15-P/categories/app_definition_and_development_application_definition_image_build.yaml
@@ -1,4 +1,6 @@
 - crunchbase: https://www.crunchbase.com/organization/hashicorp
+  description: Packer is a tool for creating identical machine images for multiple
+    platforms from a single source configuration.
   featured: true
   homepage_url: https://www.packer.io/
   logo: packer.svg

--- a/data/weeks/18-S/categories/app_definition_and_development_application_definition_image_build.yaml
+++ b/data/weeks/18-S/categories/app_definition_and_development_application_definition_image_build.yaml
@@ -6,7 +6,6 @@
   name: Score
   project: sandbox
   repo_url: https://github.com/score-spec/spec
-  twitter: https://twitter.com/score_dev
 - crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
   description: Standards-based DSL and open-source dev tools and runtimes are at the
     heart of the Serverless Workflow project

--- a/data/weeks/18-S/categories/app_definition_and_development_application_definition_image_build.yaml
+++ b/data/weeks/18-S/categories/app_definition_and_development_application_definition_image_build.yaml
@@ -6,6 +6,7 @@
   name: Score
   project: sandbox
   repo_url: https://github.com/score-spec/spec
+  twitter: https://twitter.com/score_dev
 - crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
   description: Standards-based DSL and open-source dev tools and runtimes are at the
     heart of the Serverless Workflow project

--- a/data/weeks/19-T/categories/provisioning_automation_configuration.yaml
+++ b/data/weeks/19-T/categories/provisioning_automation_configuration.yaml
@@ -18,8 +18,6 @@
   repo_url: https://github.com/appvia/terranetes-controller
   twitter: https://twitter.com/appvia_io
 - crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
-  description: Bare metal provisioning engine, supporting network and ISO booting,
-    BMC interactions, metadata service, and workflow engine.
   featured: true
   homepage_url: https://tinkerbell.org/
   logo: tinkerbell.svg

--- a/data/weeks/19-T/categories/provisioning_automation_configuration.yaml
+++ b/data/weeks/19-T/categories/provisioning_automation_configuration.yaml
@@ -18,6 +18,8 @@
   repo_url: https://github.com/appvia/terranetes-controller
   twitter: https://twitter.com/appvia_io
 - crunchbase: https://www.crunchbase.com/organization/cloud-native-computing-foundation
+  description: Bare metal provisioning engine, supporting network and ISO booting,
+    BMC interactions, metadata service, and workflow engine.
   featured: true
   homepage_url: https://tinkerbell.org/
   logo: tinkerbell.svg

--- a/src/pipeline/transform.py
+++ b/src/pipeline/transform.py
@@ -1,5 +1,18 @@
 from src.logger import get_logger
 
+import yaml
+from pathlib import Path
+from src.config import load_config
+
+def _get_overlay_data() -> dict:
+    config = load_config()
+    overlay_path = config.data_dir / "overlay" / "overlay.yaml"
+    if overlay_path.exists():
+        with open(overlay_path, 'r') as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
 logger = get_logger(__name__)
 
 def make_path(c: str, s: str) -> str:
@@ -40,7 +53,7 @@ def _get_featured_priority(item: dict) -> tuple:
     
     return (priority, name)
 
-def _prepare_item_for_output(item: dict, is_featured: bool = False) -> dict:
+def _prepare_item_for_output(item: dict, is_featured: bool = False, overlay_data: dict = None) -> dict:
     """
     This function prepares an item for YAML output, adding featured flag and description.
     """
@@ -61,6 +74,10 @@ def _prepare_item_for_output(item: dict, is_featured: bool = False) -> dict:
         output_item['twitter'] = item.get('twitter')
     if item.get('crunchbase'):
         output_item['crunchbase'] = item.get('crunchbase')
+
+    if overlay_data and item.get('name') in overlay_data:
+        for k, v in overlay_data[item.get('name')].items():
+            output_item[k] = v
     
     return output_item
 
@@ -187,6 +204,7 @@ def get_landscape_by_letter(landscape: list) -> dict:
     """
     logger.info("Indexing landscape data by letter")
     index = {}
+    overlay_data = _get_overlay_data()
 
     # Initialize index for all letters A-Z
     for letter_code in range(ord('A'), ord('Z') + 1):
@@ -227,7 +245,7 @@ def get_landscape_by_letter(landscape: list) -> dict:
                 # Mark top 6 as featured
                 for idx, item in enumerate(sorted_items):
                     is_featured = idx < 6
-                    prepared_item = _prepare_item_for_output(item, is_featured)
+                    prepared_item = _prepare_item_for_output(item, is_featured, overlay_data)
 
                     if path not in index[letter]['partial']:
                         index[letter]['partial'][path] = []

--- a/src/pipeline/transform.py
+++ b/src/pipeline/transform.py
@@ -1,17 +1,15 @@
 from src.logger import get_logger
 
 import yaml
+from pathlib import Path
 from src.config import load_config
 
 def _get_overlay_data() -> dict:
     config = load_config()
     overlay_path = config.data_dir / "overlay" / "overlay.yaml"
     if overlay_path.exists():
-        with overlay_path.open(encoding='utf-8') as f:
-            data = yaml.safe_load(f)
-        if not isinstance(data, dict):
-            return {}
-        return data
+        with open(overlay_path, 'r') as f:
+            return yaml.safe_load(f) or {}
     return {}
 
 
@@ -77,12 +75,9 @@ def _prepare_item_for_output(item: dict, is_featured: bool = False, overlay_data
     if item.get('crunchbase'):
         output_item['crunchbase'] = item.get('crunchbase')
 
-    if overlay_data:
-        patch = overlay_data.get(item.get('name'))
-        if isinstance(patch, dict):
-            for k, v in patch.items():
-                if output_item.get(k) is None:
-                    output_item[k] = v
+    if overlay_data and item.get('name') in overlay_data:
+        for k, v in overlay_data[item.get('name')].items():
+            output_item[k] = v
     
     return output_item
 

--- a/src/pipeline/transform.py
+++ b/src/pipeline/transform.py
@@ -1,15 +1,17 @@
 from src.logger import get_logger
 
 import yaml
-from pathlib import Path
 from src.config import load_config
 
 def _get_overlay_data() -> dict:
     config = load_config()
     overlay_path = config.data_dir / "overlay" / "overlay.yaml"
     if overlay_path.exists():
-        with open(overlay_path, 'r') as f:
-            return yaml.safe_load(f) or {}
+        with overlay_path.open(encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
     return {}
 
 
@@ -75,9 +77,12 @@ def _prepare_item_for_output(item: dict, is_featured: bool = False, overlay_data
     if item.get('crunchbase'):
         output_item['crunchbase'] = item.get('crunchbase')
 
-    if overlay_data and item.get('name') in overlay_data:
-        for k, v in overlay_data[item.get('name')].items():
-            output_item[k] = v
+    if overlay_data:
+        patch = overlay_data.get(item.get('name'))
+        if isinstance(patch, dict):
+            for k, v in patch.items():
+                if output_item.get(k) is None:
+                    output_item[k] = v
     
     return output_item
 


### PR DESCRIPTION
Implement an overlay mechanism in the ETL pipeline to allow patching missing fields for projects (such as missing descriptions) without touching the raw upstream ETL outcomes. Adds `data/overlay/overlay.yaml` to hold patches, which are loaded and merged dynamically during the ETL process in `src/pipeline/transform.py`.

---
*PR created automatically by Jules for task [6778949409403533160](https://jules.google.com/task/6778949409403533160) started by @xNok*