### PR TITLE
Update UI string references from 26-week to 52-week

### DIFF
--- a/website/themes/cncf-theme/layouts/partials/nav.html
+++ b/website/themes/cncf-theme/layouts/partials/nav.html
@@ -13,7 +13,7 @@
             <div class="h-4 w-px bg-slate-300"></div>
             <div class="flex items-center gap-2 text-sm bg-blue-50 text-blue-700 px-3 py-1 rounded-full font-semibold">
                 <i data-lucide="check-circle-2" class="w-4 h-4"></i>
-                <span>Week {{ add (.Params.week | default 0) 1 }} of 26</span>
+                <span>Weeks {{ add (mul (.Params.week | default 0) 2) 1 }}-{{ add (mul (.Params.week | default 0) 2) 2 }} of 52</span>
             </div>
         </div>
     </div>

--- a/website/themes/cncf-theme/layouts/partials/progress.html
+++ b/website/themes/cncf-theme/layouts/partials/progress.html
@@ -1,7 +1,7 @@
 {{ $current := .current }}
 <div class="mb-12">
     <div class="flex items-center justify-between mb-4">
-        <h2 class="text-sm font-bold uppercase tracking-widest text-slate-500">The 26-Week Journey</h2>
+        <h2 class="text-sm font-bold uppercase tracking-widest text-slate-500">The 52-Week Journey</h2>
         <span class="text-sm font-medium text-slate-600" id="progress-text">{{ if $current }}{{ mul (div (add $current.index 1.0) 26.0) 100 | printf "%.0f" }}{{ else }}12{{ end }}% Complete</span>
     </div>
     <div id="alphabet-container" class="flex items-center gap-1 overflow-x-auto pb-4 no-scrollbar" role="navigation" aria-label="Alphabet Progress">

--- a/website/themes/cncf-theme/layouts/partials/progress.html
+++ b/website/themes/cncf-theme/layouts/partials/progress.html
@@ -2,7 +2,7 @@
 <div class="mb-12">
     <div class="flex items-center justify-between mb-4">
         <h2 class="text-sm font-bold uppercase tracking-widest text-slate-500">The 52-Week Journey</h2>
-        <span class="text-sm font-medium text-slate-600" id="progress-text">{{ if $current }}{{ mul (div (add $current.index 1.0) 26.0) 100 | printf "%.0f" }}{{ else }}12{{ end }}% Complete</span>
+        <span class="text-sm font-medium text-slate-600" id="progress-text">{{ if $current }}{{ mul (div (mul (add $current.index 1.0) 2.0) 52.0) 100 | printf "%.0f" }}{{ else }}12{{ end }}% Complete</span>
     </div>
     <div id="alphabet-container" class="flex items-center gap-1 overflow-x-auto pb-4 no-scrollbar" role="navigation" aria-label="Alphabet Progress">
         {{ range $i, $seq := seq 0 25 }}


### PR DESCRIPTION
The user noticed that the CNCF landscape journey is correctly described as 52 weeks (2 weeks per letter) but some strings incorrectly labeled it as a "26-Week Journey". This PR fixes the `progress.html` and `nav.html` UI components to show "52-Week Journey" and accurately display the weeks string as `Weeks <Start>-<End> of 52`.

---
*PR created automatically by Jules for task [13521402568858056579](https://jules.google.com/task/13521402568858056579) started by @xNok*