### PR TITLE
Add GitHub repository link to the home page navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-05-30 - Standardized Empty States
 **Learning:** Generic unstyled text like "No data available" provides poor UX and lacks visual hierarchy. Creating a consistent, styled empty state pattern using `bg-slate-50`, dashed borders, and a Lucide icon (like `inbox`) significantly improves the visual appeal and provides helpful context when data is missing.
 **Action:** Use this standard Tailwind empty state design pattern (`bg-slate-50 border-2 border-dashed border-slate-200 rounded-2xl p-12 text-center flex flex-col items-center justify-center`) across all pages when handling missing or empty data.
+
+## 2024-08-20 - Adding GitHub Icon
+**Learning:** The default Lucide script configuration in the project might not include all icons by default or there might be an issue dynamically rendering the `github` icon using `<i data-lucide="github"></i>`.
+**Action:** When adding specific icons like GitHub that fail to render via the `data-lucide` attribute, use the inline SVG representation of the Lucide icon instead to guarantee visibility.

--- a/website/themes/cncf-theme/layouts/partials/nav.html
+++ b/website/themes/cncf-theme/layouts/partials/nav.html
@@ -11,6 +11,11 @@
             <a href="/newsletter-preview/" class="text-sm font-medium text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">Newsletter</a>
             <a href="/watchlist-preview/" class="text-sm font-medium text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">My Watchlist</a>
             <div class="h-4 w-px bg-slate-300"></div>
+            <a href="https://github.com/mekitmedia/cncf-landscape-a-to-z" target="_blank" rel="noopener noreferrer" aria-label="GitHub Repository" title="View on GitHub" class="flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-github"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
+                GitHub
+            </a>
+            <div class="h-4 w-px bg-slate-300"></div>
             <div class="flex items-center gap-2 text-sm bg-blue-50 text-blue-700 px-3 py-1 rounded-full font-semibold">
                 <i data-lucide="check-circle-2" class="w-4 h-4"></i>
                 <span>Weeks {{ add (mul (.Params.week | default 0) 2) 1 }}-{{ add (mul (.Params.week | default 0) 2) 2 }} of 52</span>


### PR DESCRIPTION
This PR adds a GitHub link to the primary navigation bar. The link directs to the project's repository (`https://github.com/mekitmedia/cncf-landscape-a-to-z`) and includes an inline SVG of the GitHub icon to ensure rendering visibility alongside the "GitHub" text. Security and accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`, `aria-label`) have also been applied.

---
*PR created automatically by Jules for task [12411147586455678170](https://jules.google.com/task/12411147586455678170) started by @xNok*