### PR TITLE
Update Hugo Google Analytics config and inject partial

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,9 @@
 ## 2024-08-20 - Adding GitHub Icon
 **Learning:** The default Lucide script configuration in the project might not include all icons by default or there might be an issue dynamically rendering the `github` icon using `<i data-lucide="github"></i>`.
 **Action:** When adding specific icons like GitHub that fail to render via the `data-lucide` attribute, use the inline SVG representation of the Lucide icon instead to guarantee visibility.
+## 2025-03-05 - Hugo Google Analytics
+**Learning:** Google Analytics snippet needs to be manually added to the <head> block in Hugo layouts using . It is not injected automatically by default. Also, Hugo configuration format changed from using `googleAnalyticsID` under `[params]` to `[services.googleAnalytics] id = '...' `.
+**Action:** Always inject the google analytics partial manually to `baseof.html` or `head.html` and format the `hugo.toml` according to the `[services.googleAnalytics]` spec.
+## 2025-03-05 - Hugo Google Analytics
+**Learning:** Google Analytics snippet needs to be manually added to the <head> block in Hugo layouts using `{{ template "_internal/google_analytics.html" . }}`. It is not injected automatically by default. Also, Hugo configuration format changed from using `googleAnalyticsID` under `[params]` to `[services.googleAnalytics] id = '...'`.
+**Action:** Always inject the google analytics partial manually to `baseof.html` or `head.html` and format the `hugo.toml` according to the `[services.googleAnalytics]` spec.

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -10,8 +10,12 @@ ignoreFiles = ['README\.md$']
   description = "A 52-week journey through the CNCF Landscape, exploring one letter every two weeks."
   author = "CNCF Journey Team"
   images = ["/images/og-image.png"] # Note: Ensure this exists or is replaced
-  googleAnalyticsID = "G-59R09R9TFR"
+
 
 [caches]
   [caches.images]
     dir = ':cacheDir/images'
+
+[services]
+  [services.googleAnalytics]
+    id = 'G-59R09R9TFR'

--- a/website/themes/cncf-theme/layouts/_default/baseof.html
+++ b/website/themes/cncf-theme/layouts/_default/baseof.html
@@ -9,6 +9,7 @@
     <!-- OpenGraph -->
     {{ template "_internal/opengraph.html" . }}
     <!-- Twitter Cards -->
+    {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/twitter_cards.html" . }}
 
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">


### PR DESCRIPTION
Updates `website/hugo.toml` to use the currently documented Hugo configuration structure (`[services.googleAnalytics]`) instead of the legacy `[params]` field, and explicitly injects the embedded Google Analytics template (`{{ template "_internal/google_analytics.html" . }}`) in `website/themes/cncf-theme/layouts/_default/baseof.html`.

---
*PR created automatically by Jules for task [3639426384616710135](https://jules.google.com/task/3639426384616710135) started by @xNok*